### PR TITLE
Fastify: fix build script

### DIFF
--- a/projects/fastify/build.sh
+++ b/projects/fastify/build.sh
@@ -34,8 +34,8 @@ npm install
 cd $SRC/fastify-bearer-auth
 npm install
 
-#cd $SRC/fastify-plugin
-#npm install
+cd $SRC/fastify-plugin
+npm install
 
 cd $SRC/fastify-cookie
 npm install
@@ -43,12 +43,12 @@ npm install
 cd $SRC/fastify-cors
 npm install
 
-#cd $SRC/fastify-secure-session
-#npm install
+cd $SRC/fastify-secure-session
+npm install
 
 cd $SRC/fastify
 npm install
-npm install -g @jazzer.js/core
+npm install --save-dev @jazzer.js/core
 
 # Copy Fasity plugin
 cp -r $SRC/fast-json-stringify $OUT/
@@ -57,10 +57,10 @@ cp -r $SRC/fastify-response-validation $OUT/
 cp -r $SRC/fastify-auth $OUT/
 cp -r $SRC/fastify-basic-auth $OUT/
 cp -r $SRC/fastify-bearer-auth $OUT/
-#cp -r $SRC/fastify-plugin $OUT/
+cp -r $SRC/fastify-plugin $OUT/
 cp -r $SRC/fastify-cookie $OUT/
 cp -r $SRC/fastify-cors $OUT/
-#cp -r $SRC/fastify-secure-session $OUT/
+cp -r $SRC/fastify-secure-session $OUT/
 
 ## Build Fuzzers.
 compile_javascript_fuzzer fastify fuzz_main.js -i fastify --sync
@@ -71,3 +71,4 @@ compile_javascript_fuzzer fastify fuzz_basic_auth.js -i fastify --sync
 compile_javascript_fuzzer fastify fuzz_bearer_auth.js -i fastify --sync
 compile_javascript_fuzzer fastify fuzz_cookie.js -i fastify --sync
 compile_javascript_fuzzer fastify fuzz_cors.js -i fastify --sync
+compile_javascript_fuzzer fastify fuzz_secure_session.js -i fastify --sync


### PR DESCRIPTION
There is a bug in the build script where the jazzer module is installed in a global location (which is /usr/lib) and this path is not accessible from the run_fuzzer image. This PR fixes the bug by changing the installation of jazzer to the local directory (which is copied to $OUT in a later script) to make the module accessible in the run_fuzzer image. This PR also uncomments some statements to make them work in production.