### PR TITLE
Fastify: Fix renamed module name

### DIFF
--- a/projects/fastify/fuzz_auth.js
+++ b/projects/fastify/fuzz_auth.js
@@ -18,7 +18,7 @@
 const { FuzzedDataProvider } = require('@jazzer.js/core');
 const Fastify = require('./fastify');
 const basic_auth = require('../fastify-basic-auth/index');
-const bearer_auth = require('../fastify-bearer-auth/lib/verifyBearerAuthFactory');
+const bearer_auth = require('../fastify-bearer-auth/lib/verify-bearer-auth-factory');
 const compare = require('../fastify-bearer-auth/lib/compare');
 const key_authenticate = require('../fastify-bearer-auth/lib/authenticate');
 const v8 = require('v8');


### PR DESCRIPTION
The `fuzz-bearer-auth/lib/verifyBearerAuthFactory.js` module has been renamed to `fuzz-bearer-auth/lib/verify-bearer-auth-factory.js` in https://github.com/fastify/fastify-bearer-auth/commit/fb4b081e4a98c299714de0eda8beb2a5b319f62c. This PR fixes the `fuzz_auth.js` fuzzer to meet the changed module name.