### PR TITLE
Move creation of temporary required directory to fuzzers

### DIFF
--- a/projects/kea/build.sh
+++ b/projects/kea/build.sh
@@ -107,8 +107,3 @@ zip -j $OUT/fuzz_dhcp_parser4_seed_corpus.zip $SRC/kea-fuzzer/corp/*.json
 zip -j $OUT/fuzz_dhcp_parser6_seed_corpus.zip $SRC/kea-fuzzer/corp/*.json
 zip -j $OUT/fuzz_agent_seed_corpus.zip $SRC/kea/src/bin/agent/tests/testdata/*.json
 zip -j $OUT/fuzz_d2_seed_corpus.zip $SRC/kea/src/bin/d2/tests/testdata/*.json
-
-# Prepare for base databse file
-mkdir -p $OUT/var/lib/kea/
-touch $OUT/var/lib/kea/kea-leases4.csv
-touch $OUT/var/lib/kea/kea-leases6.csv

--- a/projects/kea/build.sh
+++ b/projects/kea/build.sh
@@ -110,5 +110,5 @@ zip -j $OUT/fuzz_d2_seed_corpus.zip $SRC/kea/src/bin/d2/tests/testdata/*.json
 
 # Prepare for base databse file
 mkdir -p $OUT/var/lib/kea/
-touch /out/var/lib/kea/kea-leases4.csv
-touch /out/var/lib/kea/kea-leases6.csv
+touch $OUT/var/lib/kea/kea-leases4.csv
+touch $OUT/var/lib/kea/kea-leases6.csv

--- a/projects/kea/fuzz_dhcp_pkt4.cc
+++ b/projects/kea/fuzz_dhcp_pkt4.cc
@@ -35,12 +35,20 @@
 
 #include "helper_func.h"
 
+namespace fs = std::filesystem;
 using namespace isc::dhcp;
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (size < 236) {
         // package size requires at least 236 bytes
         return 0;
+    }
+
+    // Prepare the least storage directory required by the Pkt constructor
+    try {
+        fs::create_directories("var/lib/kea");
+    } catch (...) {
+        // Early exit if the directory is failed to create
     }
 
     // Initialise logging

--- a/projects/kea/fuzz_dhcp_pkt6.cc
+++ b/projects/kea/fuzz_dhcp_pkt6.cc
@@ -35,12 +35,20 @@
 
 #include "helper_func.h"
 
+namespace fs = std::filesystem;
 using namespace isc::dhcp;
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (size < 236) {
         // package size requires at least 236 bytes
         return 0;
+    }
+
+    // Prepare the least storage directory required by the Pkt constructor
+    try {
+        fs::create_directories("var/lib/kea");
+    } catch (...) {
+        // Early exit if the directory is failed to create
     }
 
     // Initialise logging


### PR DESCRIPTION
For fuzz_dhcp_pkt* to run correctly, it requires a directory to store the lease data. Originally the directory is created in the build script. But that doesn't work in the OSS-Fuzz cloud. 
This PR fixes the problem by moving the directory creation into the fuzzer logic to ensure that directory exists before each fuzzing iteration.