### PR TITLE
Fix lease path validation problem

### DIFF
--- a/projects/kea/fuzz_dhcp_pkt4.cc
+++ b/projects/kea/fuzz_dhcp_pkt4.cc
@@ -14,6 +14,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 #include <config.h>
+#include <fuzzer/FuzzedDataProvider.h>
 
 #include <dhcp/pkt4.h>
 #include <dhcp/libdhcp++.h>
@@ -21,6 +22,7 @@
 #include <dhcp4/ctrl_dhcp4_srv.h>
 #include <log/logger_support.h>
 #include <process/daemon.h>
+#include <util/filesystem.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -35,7 +37,6 @@
 
 #include "helper_func.h"
 
-namespace fs = std::filesystem;
 using namespace isc::dhcp;
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
@@ -44,12 +45,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         return 0;
     }
 
-    // Prepare the least storage directory required by the Pkt constructor
-    try {
-        fs::create_directories("var/lib/kea");
-    } catch (...) {
-        // Early exit if the directory is failed to create
-    }
+    // Randomly enable validatePath checking
+    FuzzedDataProvider fdp = FuzzedDataProvider(data, size);
+    isc::util::file::PathChecker::enableEnforcement(fdp.ConsumeBool());
 
     // Initialise logging
     setenv("KEA_LOGGER_DESTINATION", "/dev/null", 0);

--- a/projects/kea/fuzz_dhcp_pkt6.cc
+++ b/projects/kea/fuzz_dhcp_pkt6.cc
@@ -14,6 +14,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 #include <config.h>
+#include <fuzzer/FuzzedDataProvider.h>
 
 #include <dhcp/pkt6.h>
 #include <dhcp/libdhcp++.h>
@@ -21,6 +22,7 @@
 #include <dhcp6/ctrl_dhcp6_srv.h>
 #include <log/logger_support.h>
 #include <process/daemon.h>
+#include <util/filesystem.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -35,7 +37,6 @@
 
 #include "helper_func.h"
 
-namespace fs = std::filesystem;
 using namespace isc::dhcp;
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
@@ -44,12 +45,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         return 0;
     }
 
-    // Prepare the least storage directory required by the Pkt constructor
-    try {
-        fs::create_directories("var/lib/kea");
-    } catch (...) {
-        // Early exit if the directory is failed to create
-    }
+    // Randomly enable validatePath checking
+    FuzzedDataProvider fdp = FuzzedDataProvider(data, size);
+    isc::util::file::PathChecker::enableEnforcement(fdp.ConsumeBool());
 
     // Initialise logging
     setenv("KEA_LOGGER_DESTINATION", "/dev/null", 0);

--- a/projects/kea/helper_func.h
+++ b/projects/kea/helper_func.h
@@ -26,7 +26,8 @@ static const std::string JSON_CONFIG4 = R"CONFIG(
             },
             "lease-database": {
                 "type": "memfile",
-                "lfc-interval": 3600
+                "lfc-interval": 3600,
+                "name": "/tmp/kea-leases4.csv"
             },
             "valid-lifetime": 4000,
             "subnet4": [{
@@ -57,7 +58,8 @@ static const std::string JSON_CONFIG6 = R"CONFIG(
             }],
             "lease-database": {
                 "type": "memfile",
-                "lfc-interval": 3600
+                "lfc-interval": 3600,
+                "name": "/tmp/kea-leases6.csv"
             }
         }
     })CONFIG";


### PR DESCRIPTION
This PR force the lease local storage to /tmp and randomly enable strict checking to still fuzz the validatePath functions sometimes.