### PR TITLE
Remove debug output from fuzz_dhcp_pkt6.cc

### DIFF
--- a/projects/kea/fuzz_dhcp_pkt6.cc
+++ b/projects/kea/fuzz_dhcp_pkt6.cc
@@ -105,7 +105,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                 pkt->getTransid();
                 srv->processPacket(pkt);
             }
-            std::cout << "D13\n";
         } catch (const isc::Exception& e) {
             // Slient exceptions
         }


### PR DESCRIPTION
Removed debug output for packet processing.