### PR TITLE
Revert parallel build

### DIFF
--- a/projects/kea/build.sh
+++ b/projects/kea/build.sh
@@ -68,7 +68,7 @@ do
   $CXX $CXXFLAGS "$SRC/kea-fuzzer/helper_func.cc" \
     "$SRC/kea-fuzzer/${fuzzer}.cc"  \
     -Wl,--start-group $KEA_STATIC_LIBS -Wl,--end-group  \
-    $INCLUDES $LIBS $LIB_FUZZING_ENGINE -o "$OUT/${fuzzer}" &
+    $INCLUDES $LIBS $LIB_FUZZING_ENGINE -o "$OUT/${fuzzer}"
 
   if [ -f "$SRC/kea-fuzzer/${fuzzer}.dict" ]; then
     cp $SRC/kea-fuzzer/${fuzzer}.dict $OUT
@@ -94,16 +94,13 @@ do
       "$SRC/kea-fuzzer/${fuzzer}${DHCPVER}.cc" $extra_lib \
       -Wl,--start-group $KEA_STATIC_LIBS $BUILD_BASEDIR/bin/dhcp$DHCPVER/libdhcp$DHCPVER.a \
       -Wl,--end-group $INCLUDES $LIBS \
-      $LIB_FUZZING_ENGINE -o "$OUT/${fuzzer}${DHCPVER}" &
+      $LIB_FUZZING_ENGINE -o "$OUT/${fuzzer}${DHCPVER}"
 
     if [ -f "$SRC/kea-fuzzer/${fuzzer}.dict" ]; then
       cp $SRC/kea-fuzzer/${fuzzer}.dict $OUT/${fuzzer}${DHCPVER}.dict
     fi
   done
 done
-
-# Wait for the processes we started in parallel
-wait
 
 # Prepare the seeds
 zip -j $OUT/fuzz_dhcpsrv_seed_corpus.zip $SRC/kea-fuzzer/corp/*.json


### PR DESCRIPTION
This PR reverts the parallel build changes introduced in #15. Compiling and linking the Kea fuzzers requires a large amount of memory, and running multiple link processes in parallel causes the linker (ld) to be occasionally terminated by the kernel’s OOM killer. As a result, some fuzzers fail to link. This PR restores serial linking to reduce the risk of OOM failures.