### PR TITLE
Call getMAC with consumed integral in fuzz_dhcp_pkt6

### DIFF
--- a/projects/kea/fuzz_dhcp_pkt6.cc
+++ b/projects/kea/fuzz_dhcp_pkt6.cc
@@ -92,6 +92,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         pkt->getTransid();
         pkt->unpack();
         pkt->pack();
+        pkt->getMAC(fdp.ConsumeIntegral<uint32_t>());
     } catch (...) {}
 
     try {


### PR DESCRIPTION
Add call to getMAC method with consumed integral value.