### PR TITLE
Add call to underlying processdhcpquery

### DIFF
--- a/projects/kea/fuzz_dhcp_pkt4.cc
+++ b/projects/kea/fuzz_dhcp_pkt4.cc
@@ -147,6 +147,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         // Process packet
         if (srv) {
             srv->processPacket(pkt);
+            srv->processDhcp4Query(pkt, fdp.ConsumeBool());
         }
     } catch (const isc::Exception& e) {
         // Slient exceptions

--- a/projects/kea/fuzz_dhcp_pkt6.cc
+++ b/projects/kea/fuzz_dhcp_pkt6.cc
@@ -130,6 +130,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         // Process packet
         if (srv) {
             srv->processPacket(pkt);
+            srv->processDhcp6Query(pkt, fdp.ConsumeBool());
         }
     } catch (const isc::Exception& e) {
         // Slient exceptions


### PR DESCRIPTION
This PR adds call to processdhcpquery function to allow more underlying parsing and sanitising of query.