### PR TITLE
Enhance fuzz_dhcp_pkt6 with additional method calls

### DIFF
--- a/projects/kea/fuzz_dhcp_pkt6.cc
+++ b/projects/kea/fuzz_dhcp_pkt6.cc
@@ -94,6 +94,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         pkt->unpack();
         pkt->pack();
         pkt->getMAC(fdp->ConsumeIntegral<uint32_t>());
+        pkt->getName(fdp->ConsumeIntegral<uint8_t>());
+        pkt->getLabel();
     } catch (...) {}
 
     // OptionVendor parsing


### PR DESCRIPTION
Added calls to getName and getLabel methods in fuzz_dhcp_pkt6.cc.